### PR TITLE
Add inherited type names

### DIFF
--- a/Sources/SourceParsingFramework/Utilities/ASTUtils.swift
+++ b/Sources/SourceParsingFramework/Utilities/ASTUtils.swift
@@ -117,11 +117,27 @@ public extension Structure {
         return Array(set).sorted()
     }
 
-    /// The name of the inherited types of this structure.
+    /// The inherited types of this structure.
+    ///
+    /// - note: This may contain generic types such as Class<Foo>.
     public var inheritedTypes: [String] {
         let types = dictionary["key.inheritedtypes"] as? [SourceKitRepresentable] ?? []
         return types.compactMap { (item: SourceKitRepresentable) -> String? in
             ((item as? [String: String])?["key.name"])?.replacingOccurrences(of: "\n", with: "").replacingOccurrences(of: " ", with: "")
+        }
+    }
+
+    /// The names of inherited types of this structure.
+    ///
+    /// - note: This property does not include any generic type
+    /// information.
+    public var inheritedTypeNames: [String] {
+        return inheritedTypes.map { (type: String) -> String in
+            if let index = type.firstIndex(of: "<") {
+                return String(type.prefix(upTo: index))
+            } else {
+                return type
+            }
         }
     }
 

--- a/Tests/SourceParsingFrameworkTests/Utilities/ASTUtilsTests.swift
+++ b/Tests/SourceParsingFrameworkTests/Utilities/ASTUtilsTests.swift
@@ -34,6 +34,20 @@ class ASTUtilsTests: AbstractSourceParsingTests {
         XCTAssertEqual(types, ["SuperClass<Blah,Foo,Bar>"])
     }
 
+    func test_inheritedTypeNames_withSingleLine_verifyResult() {
+        let structure = self.structure(for: "SingleLineInheritedTypes.swift").substructures[0]
+        let types = structure.inheritedTypeNames
+
+        XCTAssertEqual(types, ["SuperClass"])
+    }
+
+    func test_inheritedTypeNames_withMultiLine_verifyResult() {
+        let structure = self.structure(for: "MultiLineInheritedTypes.swift").substructures[0]
+        let types = structure.inheritedTypeNames
+
+        XCTAssertEqual(types, ["SuperClass"])
+    }
+
     func test_type_name_returnType_verifyResults() {
         let structure = self.structure(for: "Types.swift")
 


### PR DESCRIPTION
`inheritedTypeNames` property strips the generic type info.