### PR TITLE
Update to Xcode 10.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "CommandFramework", targets: ["CommandFramework"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.23.0"),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.23.1"),
         .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
         .package(url: "https://github.com/uber/swift-concurrency.git", .upToNextMajor(from: "0.6.5")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(
@@ -8,15 +8,15 @@ let package = Package(
         .library(name: "CommandFramework", targets: ["CommandFramework"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.20.0"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.23.0"),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
         .package(url: "https://github.com/uber/swift-concurrency.git", .upToNextMajor(from: "0.6.5")),
     ],
     targets: [
         .target(
             name: "SourceParsingFramework",
             dependencies: [
-                "Utility",
+                "SPMUtility",
                 "Concurrency",
                 "SourceKittenFramework",
             ]),
@@ -29,9 +29,9 @@ let package = Package(
         .target(
             name: "CommandFramework",
             dependencies: [
-                "Utility",
+                "SPMUtility",
                 "SourceParsingFramework",
             ]),
     ],
-    swiftLanguageVersions: [4]
+    swiftLanguageVersions: [.v4_2]
 )

--- a/Sources/CommandFramework/AbstractCommand.swift
+++ b/Sources/CommandFramework/AbstractCommand.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 import SourceParsingFramework
-import Utility
+import SPMUtility
 
 /// The base class of all commands that perform a set of logic common
 /// to all commands.

--- a/Sources/CommandFramework/Command.swift
+++ b/Sources/CommandFramework/Command.swift
@@ -15,7 +15,7 @@
 //
 
 import Foundation
-import Utility
+import SPMUtility
 
 /// A specific Needle instruction to be executed based on a set of input
 /// arguments.

--- a/Sources/CommandFramework/Extensions.swift
+++ b/Sources/CommandFramework/Extensions.swift
@@ -15,9 +15,9 @@
 //
 
 import Foundation
-import Utility
+import SPMUtility
 
-public extension ArgumentParser.Result {
+extension ArgumentParser.Result {
 
     public func get(_ arg: OptionArgument<Int>, withDefault defaultValue: Double) -> Double {
         if let value = get(arg) {

--- a/Sources/SourceParsingFramework/Utilities/ASTUtils.swift
+++ b/Sources/SourceParsingFramework/Utilities/ASTUtils.swift
@@ -19,7 +19,7 @@ import SourceKittenFramework
 
 /// Extension of SourceKitten `Structure` to provide easy access to a set
 /// of common AST properties.
-public extension Structure {
+extension Structure {
 
     /// The substructures of this structure.
     public var substructures: [Structure] {

--- a/Sources/SourceParsingFramework/Utilities/Extensions.swift
+++ b/Sources/SourceParsingFramework/Utilities/Extensions.swift
@@ -18,7 +18,7 @@ import Basic
 import Foundation
 
 /// Utility String extensions.
-public extension String {
+extension String {
 
     /// The SHA256 value of this String.
     public var shortSHA256Value: String {
@@ -71,7 +71,7 @@ public extension String {
 }
 
 /// Utility URL extensions.
-public extension URL {
+extension URL {
 
     /// Initializer.
     ///
@@ -99,7 +99,7 @@ public extension URL {
 }
 
 /// Sequence extensions.
-public extension Sequence where Element: Hashable {
+extension Sequence where Element: Hashable {
 
     /// Checks if any elements of this sequence is in the given set.
     ///


### PR DESCRIPTION
This removes the warnings raised in Xcode 10.2. SourceKitten still has a dependency on SWXMLHash 4.8.0 which is not supporting Xcode 10.2 yet. A separate PR will be created for SourceKitten to address that.