### PR TITLE
(Sort of) rollback to Xcode 10.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,14 +9,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.23.1"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
         .package(url: "https://github.com/uber/swift-concurrency.git", .upToNextMajor(from: "0.6.5")),
     ],
     targets: [
         .target(
             name: "SourceParsingFramework",
             dependencies: [
-                "SPMUtility",
+                "Utility",
                 "Concurrency",
                 "SourceKittenFramework",
             ]),
@@ -29,7 +29,7 @@ let package = Package(
         .target(
             name: "CommandFramework",
             dependencies: [
-                "SPMUtility",
+                "Utility",
                 "SourceParsingFramework",
             ]),
     ],

--- a/Sources/CommandFramework/AbstractCommand.swift
+++ b/Sources/CommandFramework/AbstractCommand.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 import SourceParsingFramework
-import SPMUtility
+import Utility
 
 /// The base class of all commands that perform a set of logic common
 /// to all commands.

--- a/Sources/CommandFramework/Command.swift
+++ b/Sources/CommandFramework/Command.swift
@@ -15,7 +15,7 @@
 //
 
 import Foundation
-import SPMUtility
+import Utility
 
 /// A specific Needle instruction to be executed based on a set of input
 /// arguments.

--- a/Sources/CommandFramework/Extensions.swift
+++ b/Sources/CommandFramework/Extensions.swift
@@ -15,7 +15,7 @@
 //
 
 import Foundation
-import SPMUtility
+import Utility
 
 extension ArgumentParser.Result {
 


### PR DESCRIPTION
- We need Xcode 10.1 to create binaries with the swift libs embedded (CI machines have some 10.14.3 ones)
- SPM is using the master brach of llbuild which is now already on SPM 5.0 spec and is breaking our builds