### PR TITLE
Allow `key.name` to be `nil`

### DIFF
--- a/Sources/SourceParsingFramework/Utilities/ASTUtils.swift
+++ b/Sources/SourceParsingFramework/Utilities/ASTUtils.swift
@@ -38,7 +38,7 @@ extension Structure {
     /// The type name of this structure.
     public var name: String {
         /// The type name of this structure.
-        return dictionary["key.name"] as! String
+        return dictionary["key.name"] as? String ?? ""
     }
 
     /// The type of this structure.


### PR DESCRIPTION
In some cases (e.g. String Interpolation) `key.name` will be `nil` for a `source.lang.expr.call`.

Here is an example source code that creates this:

```swift
guard let cacheURL = FileManager.default.flagshipURL(for: .featuresPlist) else {
    preconditionFailure("Invalid flagship URL for \(FileManager.CachedFile.featuresPlist.rawValue)")
}
```

And here is it's print out of `dictionary` that exhibits this:

```
{
    "key.elements" : [
    {
        "key.kind" : "source.lang.swift.structure.elem.condition_expr",
        "key.length" : 67,
        "key.offset" : 6055
    }
    ],
    "key.kind" : "source.lang.swift.stmt.guard",
    "key.length" : 204,
    "key.namelength" : 0,
    "key.nameoffset" : 0,
    "key.offset" : 6049,
    "key.substructure" : [
    {
        "key.kind" : "source.lang.swift.decl.var.local",
        "key.length" : 8,
        "key.name" : "cacheURL",
        "key.namelength" : 8,
        "key.nameoffset" : 6059,
        "key.offset" : 6059
    },
    {
        "key.bodylength" : 19,
        "key.bodyoffset" : 6102,
        "key.kind" : "source.lang.swift.expr.call",
        "key.length" : 52,
        "key.name" : "FileManager.default.flagshipURL",
        "key.namelength" : 31,
        "key.nameoffset" : 6070,
        "key.offset" : 6070,
        "key.substructure" : [
        {
            "key.bodylength" : 14,
            "key.bodyoffset" : 6107,
            "key.kind" : "source.lang.swift.expr.argument",
            "key.length" : 19,
            "key.name" : "for",
            "key.namelength" : 3,
            "key.nameoffset" : 6102,
            "key.offset" : 6102
        }
        ]
    },
    {
        "key.bodylength" : 123,
        "key.bodyoffset" : 6129,
        "key.kind" : "source.lang.swift.stmt.brace",
        "key.length" : 125,
        "key.namelength" : 0,
        "key.nameoffset" : 0,
        "key.offset" : 6128,
        "key.substructure" : [
        {
            "key.bodylength" : 80,
            "key.bodyoffset" : 6162,
            "key.kind" : "source.lang.swift.expr.call",
            "key.length" : 101,
            "key.name" : "preconditionFailure",
            "key.namelength" : 19,
            "key.nameoffset" : 6142,
            "key.offset" : 6142,
            "key.substructure" : [
            {
                "key.bodylength" : 0,
                "key.bodyoffset" : 6242,
                "key.kind" : "source.lang.swift.stmt.brace",
                "key.length" : 81,
                "key.namelength" : 0,
                "key.nameoffset" : 0,
                "key.offset" : 6162,
                "key.substructure" : [
                {
                    "key.bodylength" : 50,
                    "key.bodyoffset" : 6190,
                    "key.kind" : "source.lang.swift.expr.call",
                    "key.length" : 52,
                    "key.namelength" : 0,
                    "key.nameoffset" : 6189,
                    "key.offset" : 6189
                }
                ]
            }
            ]
        }
        ]
    }
    ]
},
```

Removing the string interpolation removes the `source.lang.swift.expr.call` without a `key.name`.