### PR TITLE
Link to the static version of SwiftToolsSupport

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .target(
             name: "SourceParsingFramework",
             dependencies: [
-                "SwiftToolsSupport",
+                "SwiftToolsSupport-auto",
                 "Concurrency",
                 "SourceKittenFramework",
             ]),
@@ -29,7 +29,7 @@ let package = Package(
         .target(
             name: "CommandFramework",
             dependencies: [
-                "SwiftToolsSupport",
+                "SwiftToolsSupport-auto",
                 "SourceParsingFramework",
             ]),
     ],


### PR DESCRIPTION
In last release 0.3.0, we switched over to depend on `swift-tools-support-core`.
There are two versions of that library: [dynamic and static](https://github.com/apple/swift-tools-support-core/blob/master/Package.swift). We initially selected the dynamic version. 

This PR changes to the static version. As we build Swift CLI tools that depend on `swift-common`, .dylib causes distribution problems. 
```
dyld: Library not loaded: <Hard-coded-local-path>/libSwiftToolsSuppport.dylib
```
I ran into this when building an internal tool, and needle could run into this too if it were updated to depend on the latest version of `swift-common`.